### PR TITLE
Explain how to set the region used by the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ Additional capabilities for file inclusion, etc.
 - `load_from_file(filename)`: load the named file by a given type; currently handles YAML, JSON, and Ruby
 - `interpolate(string)`: embed CFN references into a string (`{{ref('Service')}}`) for later interpretation by the CFN engine
 - `Table.load(filename)`: load a table from the listed file, which can then be turned into mappings (via `get_map`)
+
+### Default Region
+
+The tool defaults to region 'us-east-1'. To change this set either 'EC2_REGION' or 'AWS_DEFAULT_REGION' environment variables.


### PR DESCRIPTION
Without setting the environment variable, my existing template which was converted to ruby failed as follows:
```
Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:353:in `fetch': key not found: :"us-east-1" (KeyError)
	from /Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:353:in `get'
	from /Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:354:in `find_in_map'
	from ./ssl_autoscale-STAN-1574.rb:385:in `block in <main>'
	from /Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:246:in `instance_eval'
	from /Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:246:in `initialize'
	from /Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:279:in `initialize'
	from /Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:270:in `new'
	from /Library/Ruby/Gems/2.0.0/gems/cloudformation-ruby-dsl-0.4.12/lib/cloudformation-ruby-dsl/cfntemplate.rb:270:in `template'
	from ./ssl_autoscale-STAN-1574.rb:8:in `<main>'
```