### PR TITLE
Add 'bundler' as a Gem dependency

### DIFF
--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'detabulator'
   gem.add_runtime_dependency    'json'
   gem.add_runtime_dependency    'xml-simple'
+  gem.add_runtime_dependency    'bundler'
 end


### PR DESCRIPTION
Without this, the generated ruby file fails with:
```
$ ./ssl_autoscale-STAN-1574.rb
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler/setup (LoadError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from ./ssl_autoscale-STAN-1574.rb:3:in `<main>'
```
After I installed the "bundler" gem manually the error was gone and I got the expected Usage message.