### PR TITLE
Allow locals to be passed to interpolate.

### DIFF
--- a/examples/cloudformation-ruby-script.rb
+++ b/examples/cloudformation-ruby-script.rb
@@ -167,8 +167,8 @@ template do
           {:DeviceName => '/dev/sdd', :VirtualName => 'ephemeral2'},
           {:DeviceName => '/dev/sde', :VirtualName => 'ephemeral3'},
       ],
-      # Loads an external userdata script.
-      :UserData => base64(interpolate(file('userdata.sh'))),
+      # Loads an external userdata script with an interpolated argument.
+      :UserData => base64(interpolate(file('userdata.sh'), time: Time.now)),
   }
 
   resource 'InstanceProfile', :Type => 'AWS::IAM::InstanceProfile', :Properties => {

--- a/examples/userdata.sh
+++ b/examples/userdata.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
 echo "put initialization script here"
+echo "the time is {{ locals[:time] }}"
+echo "the aws region is {{ ref('AWS::Region') }}"


### PR DESCRIPTION
I found this pattern very useful for getting arbitrary parameters into files. For example, I have a `cfn-init.sh` script:

```
#!/bin/bash -xe

exec > >(tee -a /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1

echo BEGIN

apt-get install -y python-pip python-dev build-essential
pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz

cfn-init -v \
  --stack {{ ref('AWS::StackName') }} \
  --resource {{ locals[:resource_id] }} \
  --region {{ ref('AWS::Region') }}

cfn-signal -e $? \
  --stack {{ ref('AWS::StackName') }} \
  --resource {{ locals[:resource_id] }} \
  --region {{ ref('AWS::Region') }}

echo END
```

which requires the resource name. With this change, I can now do this:

```
interpolate(file('bootstrap-configs/cfn-init.sh'), { resource_id: 'MyInstance' })
```

The only way I could do this before was inlining the script into a heredoc in the ruby code, which is definitely less than ideal.