### PR TITLE
Restore cfn commands + bugfix for region option

### DIFF
--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'bundler'
   gem.add_runtime_dependency    'aws-sdk'
   gem.add_runtime_dependency    'diffy'
+  gem.add_runtime_dependency    'highline'
 end

--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -34,13 +34,17 @@ require 'highline/import'
 class AwsCfn
   attr_accessor :cfn_client_instance
 
+  def initialize(**args)
+    Aws.config[:region] = args[:region] if args.key?(:region)
+  end
+
   def cfn_client
     if @cfn_client_instance == nil
         # credentials are loaded from the environment; see http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFormation/Client.html
         @cfn_client_instance = Aws::CloudFormation::Client.new(
         # we don't validate parameters because the aws-ruby-sdk gets a number parameter and expects it to be a string and fails the validation
         # see: https://github.com/aws/aws-sdk-ruby/issues/848
-        validate_params: false
+        validate_params: false,
       )
     end
     @cfn_client_instance
@@ -48,6 +52,7 @@ class AwsCfn
 end
 
 # utility class to deserialize Structs as JSON
+# borrowed from http://ruhe.tumblr.com/post/565540643/generate-json-from-ruby-struct
 class Struct
   def to_map
     map = Hash.new
@@ -127,7 +132,7 @@ def validate_action(action)
 end
 
 def cfn(template)
-  aws_cfn = AwsCfn.new
+  aws_cfn = AwsCfn.new(region: template.aws_region)
   cfn_client = aws_cfn.cfn_client
 
   action = validate_action( ARGV[0] )

--- a/lib/cloudformation-ruby-dsl/version.rb
+++ b/lib/cloudformation-ruby-dsl/version.rb
@@ -15,7 +15,7 @@
 module Cfn
   module Ruby
     module Dsl
-      VERSION = "1.0.2"
+      VERSION = "1.0.3"
     end
   end
 end


### PR DESCRIPTION
This pull request addresses two issues.

First, it restores most `cfn-*` commands, excluding the list commands (list stacks etc). This addresses #51 .

Second, it fixes a bug that was introduced in the 1.0 release, which does not correctly consider the `--region` option being passed on the command line. Instead, we were relying exclusively on the environment setting.