### PR TITLE
fixing tag comparison on diff action

### DIFF
--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -207,8 +207,8 @@ def cfn(template)
     old_parameters = old_attributes.parameters
 
     # Sort the tag strings alphabetically to make them easily comparable
-    old_tags_string = old_tags.sort.map { |tag| %Q(TAG "#{tag.key}=#{tag.value}"\n) }.join
-    tags_string     = cfn_tags.sort.map { |tag| "TAG \"#{tag}\"\n" }.join
+    old_tags_string = old_tags.map { |tag| %Q(TAG "#{tag.key}=#{tag.value}"\n) }.sort.join
+    tags_string     = cfn_tags.map { |k, v| %Q(TAG "#{k.to_s}=#{v}"\n) }.sort.join
 
     # Sort the parameter strings alphabetically to make them easily comparable
     old_parameters_string = old_parameters.sort! {|pCurrent, pNext| pCurrent.parameter_key <=> pNext.parameter_key }.map { |param| %Q(PARAMETER "#{param.parameter_key}=#{param.parameter_value}"\n) }.join
@@ -398,9 +398,9 @@ def cfn(template)
 
     # Tags are immutable in CloudFormation.  Validate against the existing stack to ensure tags haven't changed.
     # Compare the sorted arrays for an exact match
-    old_cfn_tags = old_stack.tags.map { |p| [p.key.to_sym, p.value]}
-    cfn_tags_ary = cfn_tags.to_a
-    if cfn_tags_ary.sort != old_cfn_tags
+    old_cfn_tags = old_stack.tags.map { |p| [p.key.to_sym, p.value]}.sort
+    cfn_tags_ary = cfn_tags.to_a.sort
+    if cfn_tags_ary != old_cfn_tags
       $stderr.puts "CloudFormation stack tags do not match and cannot be updated. You must either use the same tags or create a new stack." +
                       "\n" + (old_cfn_tags - cfn_tags_ary).map {|tag| "< #{tag}" }.join("\n") +
                       "\n" + "---" +


### PR DESCRIPTION
Hi friends!

First, let me say thanks for the work you do on this project! I use it heavily with great success.

I just upgraded to the aws-sdk version of the gem and found a couple of little problems in the tag comparison during the diff action.

First, the comparison was trying to sort two objects (from the existing template) ...

```
[#<struct  key="Environment", value="Production">,
 #<struct  key="Application", value="General">]
```

that it didn't know how to sort, resulting in this error:

```
gems/cloudformation-ruby-dsl-1.0.3/lib/cloudformation-ruby-dsl/cfntemplate.rb:210:in `sort': comparison of #<Class:0x000000017eeef0> with #<Class:0x000000017eeef0> failed (ArgumentError)
```

Second, the tags from the new template a) had keys that were symbols

```
{:Environment=>"Production", :Application=>"General"}
```

and b) were being built differently than the old tags

```
TAG "[:Application, "General"]"
TAG "[:Environment, "Production"]"
```

So this patch seems to clear that up.