### PR TITLE
Add support for stack metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Add the named object to the appropriate collection.
 - `condition(name, conditions)`
 - `resource(name, options)`
 - `output(name, options)`
+- `metadata(object)`
 
 ### CloudFormation Function Calls
 

--- a/bin/cfntemplate-to-ruby
+++ b/bin/cfntemplate-to-ruby
@@ -113,6 +113,8 @@ def pprint_cfn_template(tpl)
   puts
   tpl.each do |section, v|
     case section
+      when 'Metadata'
+        v.each { |name, options| pprint_cfn_section 'metadata', name, options }        
       when 'Parameters'
         v.each { |name, options| pprint_cfn_section 'parameter', name, options }
       when 'Mappings'

--- a/examples/cloudformation-ruby-script.rb
+++ b/examples/cloudformation-ruby-script.rb
@@ -23,13 +23,27 @@ require 'cloudformation-ruby-dsl/table'
 
 template do
 
-  # Metadata may be embedded into the stack, as per http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
-  stack_metadata = {
-    :MyCustomKey => 'MyCustomValue',
-    :AnotherKey => [ 'value1', 'value2' ]
+  # Metadata may be embedded into the stack, as per http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html 
+  # The below definition produces CloudFormation interface metadata.
+  metadata 'AWS::CloudFormation::Interface', {
+    :ParameterGroups => [
+      {
+        :Label => { :default => 'Instance options' },
+        :Parameters => [ 'InstanceType', 'ImageId', 'KeyPairName' ]
+      },
+      {
+        :Label => { :default => 'Other options' },
+        :Parameters => [ 'Label', 'EmailAddress' ]
+      }
+    ], 
+    :ParameterLabels => {
+      :EmailAddress => {
+        :default => "We value your privacy!"
+      }
+    }
   }
 
-  metadata stack_metadata
+  metadata 'fish', 'fingers'
 
   parameter 'Label',
             :Description => 'The label to apply to the servers.',

--- a/examples/cloudformation-ruby-script.rb
+++ b/examples/cloudformation-ruby-script.rb
@@ -23,6 +23,14 @@ require 'cloudformation-ruby-dsl/table'
 
 template do
 
+  # Metadata may be embedded into the stack, as per http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
+  stack_metadata = {
+    :MyCustomKey => 'MyCustomValue',
+    :AnotherKey => [ 'value1', 'value2' ]
+  }
+
+  metadata stack_metadata
+
   parameter 'Label',
             :Description => 'The label to apply to the servers.',
             :Type => 'String',

--- a/examples/cloudformation-ruby-script.rb
+++ b/examples/cloudformation-ruby-script.rb
@@ -43,8 +43,6 @@ template do
     }
   }
 
-  metadata 'fish', 'fingers'
-
   parameter 'Label',
             :Description => 'The label to apply to the servers.',
             :Type => 'String',

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -122,6 +122,8 @@ class TemplateDSL < JsonObjectDSL
     end
   end
 
+  def metadata(object) default(:Metadata, object) end
+
   def condition(name, options) default(:Conditions, {})[name] = options end
 
   def resource(name, options) default(:Resources, {})[name] = options end

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -122,7 +122,7 @@ class TemplateDSL < JsonObjectDSL
     end
   end
 
-  def metadata(object) default(:Metadata, object) end
+  def metadata(name, options) default(:Metadata, {})[name] = options end
 
   def condition(name, options) default(:Conditions, {})[name] = options end
 


### PR DESCRIPTION
Hi!

I recently needed to embed metadata into my stacks (as described here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html)

So, I've added support for that. Apologies if I've missed anything obvious... this is, in fact, my very first pull request.

Cheers!
James