### PR TITLE
rake is not part of the bundle

### DIFF
--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'aws-sdk'
   gem.add_runtime_dependency    'diffy'
   gem.add_runtime_dependency    'highline'
+  gem.add_runtime_dependency    'rake'
 end


### PR DESCRIPTION
Fix below issue when run `rake -T`
```
$ bundle exec rake -T
/Users/bill/.rvm/gems/ruby-2.0.0-p643/gems/bundler-1.10.6/lib/bundler/rubygems_integration.rb:292:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
	from /Users/bill/.rvm/gems/ruby-2.0.0-p643/bin/rake:22:in `<main>'
	from /Users/bill/.rvm/gems/ruby-2.0.0-p643/bin/ruby_executable_hooks:15:in `eval'
	from /Users/bill/.rvm/gems/ruby-2.0.0-p643/bin/ruby_executable_hooks:15:in `<main>'
```