### PR TITLE
Added a possibility to get table header as list

### DIFF
--- a/lib/cloudformation-ruby-dsl/table.rb
+++ b/lib/cloudformation-ruby-dsl/table.rb
@@ -21,14 +21,19 @@ class Table
 
   def initialize(table_as_text)
     raw_header, *raw_data = Detabulator.new.detabulate table_as_text
-    header = raw_header.map(&:to_sym)
-    @records = raw_data.map { |row| Hash[header.zip(row)] }
+    @header = raw_header.map(&:to_sym)
+    @records = raw_data.map { |row| Hash[@header.zip(row)] }
   end
 
   # Selects all rows in the table which match the name/value pairs of the predicate object and returns
   # the single distinct value from those rows for the specified key.
   def get(key, predicate)
     distinct_values(filter(predicate), key, false)
+  end
+
+  # Select the headers as list. Argument(s) will be excluded from output.
+  def get_header(*exclude)
+    @header.reject{ |key| key if exclude.include?(key) }
   end
 
   # Selects all rows in the table which match the name/value pairs of the predicate object and returns

--- a/lib/cloudformation-ruby-dsl/version.rb
+++ b/lib/cloudformation-ruby-dsl/version.rb
@@ -15,7 +15,7 @@
 module Cfn
   module Ruby
     module Dsl
-      VERSION = "1.0.5"
+      VERSION = "1.1.0"
     end
   end
 end


### PR DESCRIPTION
It can be used as parameter in function "get_multihash" when we need to make a whole map from table. For example:
table (ami.txt):
```
region        hvm_ebs       hvm_s3        pv_ebs        pv_s3
us-east-1     ami-60b6c60a  ami-66b6c60c  ami-5fb8c835  ami-30b6c65a
us-west-2     ami-f0091d91  ami-31342050  ami-d93622b8  ami-960317f7
eu-west-1     ami-bff32ccc  ami-54e03f27  ami-95e33ce6  ami-54e53a27
```
Ruby code:
```
ami = Table.load File.dirname(__FILE__) + '/ami.txt'
mapping 'AmiMap', ami.get_multihash(:region, {}, *ami.get_header(:region))
```
map:
```
    "AmiMap": {
      "us-east-1": {
        "hvm_ebs": "ami-60b6c60a",
        "hvm_s3": "ami-66b6c60c",
        "pv_ebs": "ami-5fb8c835",
        "pv_s3": "ami-30b6c65a"
      },
      "us-west-2": {
        "hvm_ebs": "ami-f0091d91",
        "hvm_s3": "ami-31342050",
        "pv_ebs": "ami-d93622b8",
        "pv_s3": "ami-960317f7"
      },
      "eu-west-1": {
        "hvm_ebs": "ami-bff32ccc",
        "hvm_s3": "ami-54e03f27",
        "pv_ebs": "ami-95e33ce6",
        "pv_s3": "ami-54e53a27"
      }
    },
```