### PR TITLE
Example - Depend on existing stack resource

### DIFF
--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -62,6 +62,7 @@ class TemplateDSL < JsonObjectDSL
     @aws_region = aws_region
     @aws_profile = aws_profile
     @nopretty = nopretty
+    @loaded_remote_resources = {}
     super()
   end
 
@@ -169,6 +170,20 @@ def find_in_map(map, key, name) { :'Fn::FindInMap' => [ map, key, name ] } end
 def get_att(resource, attribute) { :'Fn::GetAtt' => [ resource, attribute ] } end
 
 def get_azs(region = '') { :'Fn::GetAZs' => region } end
+
+def load_remote_resources(name, stack_name)
+  @loaded_remote_resources[name] = {}
+  aws_cfn = AwsCfn.new({:region => @aws_region, :aws_profile => @aws_profile})
+  cfn_client = aws_cfn.cfn_client
+  resources = cfn_client.describe_stack_resources({stack_name: stack_name,}).stack_resources
+  resources.each do |resource|
+    @loaded_remote_resources[name][resource['logical_resource_id']] = resource['physical_resource_id']
+  end
+end
+
+def get_remote_resource_id(name, resource_name)
+  @loaded_remote_resources[name][resource_name]
+end
 
 def join(delim, *list)
   case list.length


### PR DESCRIPTION
First off, I want to say thank you for creating this cf-ruby. It has made my life much easier.

I recently used [terraform](https://www.terraform.io/) on a project and terraform has a concept of depending on existing stacks. I thought it would be awesome to have a way for cf-ruby-dsl to support the same concept.

Usage could be something like launching all your infrastructure (vpc, subnets, routes, etc), then launching your applications into that infrastructure with this functionality.

Usage would be something like this:
`load_remote_resources 'base_network', 'my-existing-cloudformation-stack'`

`resource 'PublicSubnet', Type: 'AWS::EC2::Subnet', Properties: {`
`VpcId: get_remote_resource_id('base_network', 'VPC'),`
`CidrBlock: '10.0.0.0/24',`
`}`

This is my best stab at adding that functionality. I am not happy about having to instantiate an additional cfn_client, and was not sure about function names. 

Is this a feature you would be interested in adding?
Can you think of a better way to accomplish this task?

Thanks!