### PR TITLE
Updated profile definition with usage the environment variables

### DIFF
--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'detabulator'
   gem.add_runtime_dependency    'json'
   gem.add_runtime_dependency    'bundler'
-  gem.add_runtime_dependency    'aws-sdk', '2.4.1'
+  gem.add_runtime_dependency    'aws-sdk', '>=2.5.1'
   gem.add_runtime_dependency    'diffy'
   gem.add_runtime_dependency    'highline'
   gem.add_runtime_dependency    'rake'

--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -36,7 +36,15 @@ class AwsCfn
 
   def initialize(args)
     Aws.config[:region] = args[:region] if args.key?(:region)
-    Aws.config[:credentials] = Aws::SharedCredentials.new(profile_name: args[:aws_profile]) unless args[:aws_profile].nil?
+    # Profile definition was replaced with environment variables
+    if args.key?(:aws_profile)
+        ENV['AWS_PROFILE'] = args[:aws_profile]
+        ENV['AWS_ACCESS_KEY'] = nil
+        ENV['AWS_ACCESS_KEY_ID'] = nil
+        ENV['AMAZON_ACCESS_KEY_ID'] = nil
+    end
+    # Following line can be uncommented only when Amazon will provide the stable version of this functionality.
+    # Aws.config[:credentials] = Aws::SharedCredentials.new(profile_name: args[:aws_profile]) unless args[:aws_profile].nil?
   end
 
   def cfn_client

--- a/lib/cloudformation-ruby-dsl/version.rb
+++ b/lib/cloudformation-ruby-dsl/version.rb
@@ -15,7 +15,7 @@
 module Cfn
   module Ruby
     module Dsl
-      VERSION = "1.2.2"
+      VERSION = "1.2.3"
     end
   end
 end


### PR DESCRIPTION
The **shared_credential** and **shared_config** functionality still under development - aws/aws-sdk-ruby@133c252 (less then 1 day ago), but usage the environment variables looks stable. So the profile definition was updated with environment variables.