### PR TITLE
check that ags[:aws_profile] is not nil or empty

### DIFF
--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -37,7 +37,7 @@ class AwsCfn
   def initialize(args)
     Aws.config[:region] = args[:region] if args.key?(:region)
     # Profile definition was replaced with environment variables
-    if args.key?(:aws_profile)
+    if args.key?(:aws_profile) && !(args[:aws_profile].nil? || args[:aws_profile].empty?)
         ENV['AWS_PROFILE'] = args[:aws_profile]
         ENV['AWS_ACCESS_KEY'] = nil
         ENV['AWS_ACCESS_KEY_ID'] = nil


### PR DESCRIPTION
https://github.com/bazaarvoice/cloudformation-ruby-dsl/pull/91 broke things.  Perhaps it went unnoticed by people whose default profile is getting picked up automagically.

When the initializer for AwsCfn is called in the cfn method, it sets
aws_profile. So when the user is not purposefully setting aws_profile,
the authentication env variables were being blown away because the
aws_profile key existed.