### PR TITLE
Basic acceptance tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,9 @@
 require "bundler/gem_tasks"
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
+
+task :default => :spec

--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'rake'
 
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'pry'
 end

--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'diffy'
   gem.add_runtime_dependency    'highline'
   gem.add_runtime_dependency    'rake'
+
+  gem.add_development_dependency 'rspec'
 end

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -9,6 +9,7 @@ To get started:
 - fork this project on github
 - create a new branch named after the change you want to make; i.e., `git checkout -b mynewfeature`
 - make your changes and commit them
+- run the tests to make sure you haven't broken anything: ```rspec```
 - send a pull request to this project from your fork/branch
 
 Once you've sent your pull request, one of the project collaborators will review it and provide feedback. Please accept this commentary as constructive! It is intended as such.

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -8,7 +8,7 @@ To get started:
 
 - fork this project on github
 - create a new branch named after the change you want to make; i.e., `git checkout -b mynewfeature`
-- make your changes and commit them
+- make your changes (including tests) and commit them
 - run the tests to make sure you haven't broken anything: ```rspec```
 - send a pull request to this project from your fork/branch
 

--- a/examples/simple_template.rb
+++ b/examples/simple_template.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+require 'bundler/setup'
+require 'cloudformation-ruby-dsl/cfntemplate'
+
+template = template do
+  resource "HelloBucket", :Type => "AWS::S3::Bucket"
+end
+
+template.exec!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,161 @@
+require 'fileutils'
+require 'json'
+require 'open3'
+
+##
+# Error encapsulating information about a failed command
+class CommandError < StandardError
+  attr_reader :command, :status, :stderr
+
+  def initialize(command, status, stderr)
+    @command = command
+    @status = status
+    @stderr = stderr
+    super "FAILURE (#{status}) #{stderr}"
+  end
+end
+
+##
+# Helpers for dealing with pathing from specs
+module PathHelpers
+  ##
+  # Returns an absolute path for the specified path that
+  # is relative to the project root irregardless of where
+  # rspec/ruby is invoked
+  def from_project_root(relative_path)
+    source_dir = File.expand_path(File.dirname(__FILE__))
+    File.join(source_dir, "..", relative_path)
+  end
+end
+
+##
+# Mixin containing helper methods for working with
+# commands executed in a subshell
+module CommandHelpers
+  include PathHelpers
+
+  ##
+  # Logs the command that failed and raises an exception
+  # inlcuding status and stderr
+  def cmd_failed(command, status, stderr)
+    STDERR.puts("FAILURE executing #{command}")
+    raise CommandError.new(command, status, stderr)
+  end
+
+  ##
+  # execute a command within a specified directory and
+  # return results or yield them to a block if one is
+  # given to this method.  Results are an array of
+  # strings:
+  #
+  # [stdout, token1, token2, ..., tokenN]
+  #
+  # where stdout is the captured standard output and
+  # the tokens are the words extracted from the output.
+  #
+  # If the command has a non-zero  exit status, an
+  # exception is raised including the exit code
+  # and stderr.
+  #
+  # example call:
+  #   exec_cmd("ls", :within => "/")
+  def exec_cmd(cmd, opts={:within => "."})
+    exec_dir = from_project_root(opts[:within])
+    Dir.chdir(exec_dir) do
+      stdout, stderr, status = Open3.capture3(cmd)
+      results = stdout.split(" ").unshift(stdout)
+
+      cmd_failed(cmd, status, stderr) if status != 0
+      if (block_given?)
+        yield results
+      else
+        results
+      end
+    end
+  end
+end
+
+##
+# Mixin with helper methods for dealing with JSON generated
+# from cloudformation-ruby-dsl
+module JsonHelpers
+  ##
+  # Parse the json string, making sure to write all of it to
+  # STDERR if parsing fails to make it easier to troubleshoot
+  # failures in generated json.
+  def jsparse(json_string)
+    begin
+      JSON.parse(json_string)
+    rescue StandardError => e
+      STDERR.puts "Error parsing JSON:"
+      STDERR.puts json_string
+      raise e
+    end
+  end
+end
+
+##
+# Mixin with helper methods for dealing with files generated
+# from a test/spec
+module FileHelpers
+  include PathHelpers
+
+  ##
+  # Delete a file from the spec/tmp directory
+  def delete_test_file(filename)
+    abs_path = File.join(from_project_root("spec/tmp"), filename)
+    FileUtils.rm(abs_path)
+  end
+
+  ##
+  # Write a file to the spec/tmp directory
+  def write_test_file(filename, contents)
+    dest_dir = from_project_root("spec/tmp")
+    dest_file = File.join(dest_dir, filename)
+
+    FileUtils.mkdir_p(dest_dir)
+    File.open(dest_file, "w") { |f| f.write(contents) }
+    dest_file
+  end
+end
+
+##
+# Mixin to assist in using aws cli for validating results of
+# cloudformation-ruby-dsl
+module AwsHelpers
+  include CommandHelpers
+
+  ##
+  # Validate a cloudformation template within the spec/tmp directory
+  # using aws cli
+  def validate_cfn_template(template_name)
+    template_path = File.join(from_project_root("spec/tmp"), template_name)
+    command = validation_command(template_path)
+    exec_cmd(command) do |output|
+      begin
+        JSON.parse(output.first)
+      rescue JSON::ParserError
+        STDERR.puts "ERROR parsing output of: #{command}"
+        raise
+      end
+    end
+  end
+
+  def profile
+    ENV["AWS_PROFILE"] || "default"
+  end
+
+  def region
+    ENV["AWS_REGION"] || "us-east-1"
+  end
+
+  private
+
+  def validation_command(template_path)
+    return <<-EOF
+      aws cloudformation validate-template --template-body file://#{template_path} \
+                                           --region #{region} \
+                                           --profile #{profile}
+    EOF
+  end
+end

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -1,20 +1,25 @@
 require 'spec_helper'
 
-describe "cloudformation-ruby-dsl" do
+RSpec.shared_examples "template acceptance validations" do
   include CommandHelpers
   include JsonHelpers
   include FileHelpers
   include AwsHelpers
 
-  context "simplest template" do
-    let(:example_template) {"simple_template.rb"}
+  it "should create a valid JSON template from the example ruby template" do
+    delete_test_file(json_template)
+    json = exec_cmd("./#{ruby_template} expand", :within => "examples").first
+    write_test_file(json_template, json)
+    validate_cfn_template(json_template)
+  end
+end
 
-    it "should create a valid JSON template from the example ruby template" do
-      delete_test_file("simple_template.json");
-      json = exec_cmd("./#{example_template} expand", :within => "examples").first
-      write_test_file("simple_template.json", json)
-      validate_cfn_template("simple_template.json")
-    end
+describe "cloudformation-ruby-dsl" do
+  context "simplest template" do
+    let(:ruby_template) { "simple_template.rb" }
+    let(:json_template) { "simple_template.json" }
+
+    include_examples "template acceptance validations"
   end
 
   # TODO validate examples/cloudformation-ruby-script.rb

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -1,0 +1,5 @@
+describe "cloudformation-ruby-dsl" do
+  it "should pass" do
+    expect(true).to eql(true)
+  end
+end

--- a/spec/validation_spec.rb
+++ b/spec/validation_spec.rb
@@ -1,5 +1,21 @@
+require 'spec_helper'
+
 describe "cloudformation-ruby-dsl" do
-  it "should pass" do
-    expect(true).to eql(true)
+  include CommandHelpers
+  include JsonHelpers
+  include FileHelpers
+  include AwsHelpers
+
+  context "simplest template" do
+    let(:example_template) {"simple_template.rb"}
+
+    it "should create a valid JSON template from the example ruby template" do
+      delete_test_file("simple_template.json");
+      json = exec_cmd("./#{example_template} expand", :within => "examples").first
+      write_test_file("simple_template.json", json)
+      validate_cfn_template("simple_template.json")
+    end
   end
+
+  # TODO validate examples/cloudformation-ruby-script.rb
 end


### PR DESCRIPTION
Sets up a single acceptance test for the most basic case (cloudformation template that creates a single AWS bucket). Uses Rspec for testing.  Opts to validate the JSON output of the ruby DSL using aws cli tools to avoid many/any dependencies on cloudformation-ruby-dsl's internal structure/code.  Contains:

- ruby DSL file is in examples/simple_template.rb
- spec of this file is in spec/validation_spec.rb
- lots of helpers that might be reused in other specs

You can run the specs by checking out this branch and executing ```rspec``` or simply ```rake```.  This will set it up to play nicely with travis.ci.  A separate PR will get this working with travis.ci.  A third PR will include a validation of ```examples/cloudformation-ruby-script.rb``` and fixes to it (the JSON it outputs currently fails aws cli validation).

Example run:
```
./cloudformation-ruby-dsl $ rspec --format documentation

cloudformation-ruby-dsl
  simplest template
    should create a valid JSON template from the example ruby template

Finished in 1.78 seconds (files took 0.09376 seconds to load)
1 example, 0 failures
```