### PR TITLE
Changed CAPABILITY_IAM to CAPABILITY_NAMED_IAM to allow for named IAM…

### DIFF
--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -300,7 +300,7 @@ def cfn(template)
           template_body: template_string,
           parameters: template.parameters.map { |k,v| {parameter_key: k, parameter_value: v}}.to_a,
           tags: cfn_tags.map { |k,v| {"key" => k.to_s, "value" => v} }.to_a,
-          capabilities: ["CAPABILITY_IAM"],
+          capabilities: ["CAPABILITY_NAMED_IAM"],
       }
 
       # fill in options from the command line
@@ -495,7 +495,7 @@ def cfn(template)
           template_body: template_string,
           parameters: template.parameters.map { |k,v| {parameter_key: k, parameter_value: v}}.to_a,
           tags: cfn_tags.map { |k,v| {"key" => k.to_s, "value" => v.to_s} }.to_a,
-          capabilities: ["CAPABILITY_IAM"],
+          capabilities: ["CAPABILITY_NAMED_IAM"],
       }
 
       # fill in options from the command line


### PR DESCRIPTION
…. See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-template.html#using-iam-capabilities

This allows creations and updates of stacks with named IAM resources. For example, named groups.