### PR TITLE
Make options optional again

### DIFF
--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -44,7 +44,7 @@ end
 ############################# CloudFormation DSL
 
 # Main entry point
-def raw_template(options, &block)
+def raw_template(options = {}, &block)
   TemplateDSL.new(options, &block)
 end
 
@@ -62,12 +62,12 @@ class TemplateDSL < JsonObjectDSL
               :aws_profile
 
   def initialize(options)
-    @parameters  = options[:parameters]
-    @interactive = options[:interactive]
+    @parameters  = options.fetch(:parameters, {})
+    @interactive = options.fetch(:interactive, false)
     @stack_name  = options[:stack_name]
-    @aws_region  = options[:region]
+    @aws_region  = options.fetch(:region, default_region)
     @aws_profile = options[:profile]
-    @nopretty    = options[:nopretty]
+    @nopretty    = options.fetch(:nopretty, false)
     super()
   end
 


### PR DESCRIPTION
e712636 changed the arguments to `#raw_template` to a single `options` hash, unfortunately the `options` argument is not optional in itself. This caused a bunch of our code that extends the dsl and uses `#raw_template` to break as they were not using in arguments.

That change was also released under a patch version bump which is also unfortunate as it meant even a pessimistic version lock would not have prevented it from breaking. I believe releasing such a change should have been a major bump according guidelines set forth in your [release documentation](https://github.com/bazaarvoice/cloudformation-ruby-dsl/blob/master/docs/Releasing.md#versioning-specification).

The change in this PR makes the argument optional once again and sets the values to what they would have been, had they not been given.