### PR TITLE
Allow whitespace between CLI parameters

### DIFF
--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -91,7 +91,7 @@ def parse_args
     when '--stack-name'
       args[:stack_name] = value
     when '--parameters'
-      args[:parameters] = Hash[value.split(/;/).map { |pair| pair.split(/=/, 2) }]  #/# fix for syntax highlighting
+      args[:parameters] = Hash[value.split(/;\s*/).map { |pair| pair.split(/=/, 2) }]  #/# fix for syntax highlighting
     when '--interactive'
       args[:interactive] = true
     when '--region'


### PR DESCRIPTION
The splitting regex that is in place currently causes unexpected behavior for parameter strings like this:

```
--parameters "ObjectVersion=VERSION; ObjectKey=KEY"
```

In this case, `ObjectVersion` will be set as expected, but `ObjectKey` will be set to `null` since the DSL is trying to fill the parameter ` ObjectKey` with a leading space and not `ObjectKey`, without.

Based on the AWS docs I can find, it should be safe to do this, since:

> For each parameter, you must declare a logical name, which must be alphanumeric and unique among all logical names within the template.

This implies to me that whitespace is not a valid character in the Logical Name of the param, so we should be safe to ignore it like this.