### PR TITLE
Adding support for Fn::Sub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Invoke an intrinsic CloudFormation function.
 - `select(index, list)`
 - `ref(name)`
 - `import_value(value)`
+- `sub(sub_string)`
+- `sub(sub_string, var_map)`
 
 Intrinsic conditionals are also supported, with some syntactic sugar.
 - `fn_not(condition)`

--- a/examples/cloudformation-ruby-script.rb
+++ b/examples/cloudformation-ruby-script.rb
@@ -23,7 +23,7 @@ require 'cloudformation-ruby-dsl/table'
 
 template do
 
-  # Metadata may be embedded into the stack, as per http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html 
+  # Metadata may be embedded into the stack, as per http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html
   # The below definition produces CloudFormation interface metadata.
   metadata 'AWS::CloudFormation::Interface', {
     :ParameterGroups => [
@@ -35,7 +35,7 @@ template do
         :Label => { :default => 'Other options' },
         :Parameters => [ 'Label', 'EmailAddress' ]
       }
-    ], 
+    ],
     :ParameterLabels => {
       :EmailAddress => {
         :default => "We value your privacy!"
@@ -78,6 +78,10 @@ template do
   parameter 'EmailAddress',
             :Type => 'String',
             :Description => 'Email address at which to send notification events.'
+
+  parameter 'BucketName',
+            :Type => 'String',
+            :Description => 'Name of the bucket to upload to.'
 
   mapping 'InlineExampleMap',
           :team1 => {
@@ -134,7 +138,7 @@ template do
   #   These tags are excised from the template and used to generate a series of --tag arguments
   #   which are passed to CloudFormation when a stack is created.
   #   They do not ultimately appear in the expanded CloudFormation template.
-  #   The diff subcommand will compare tags with the running stack and identify any changes, 
+  #   The diff subcommand will compare tags with the running stack and identify any changes,
   #   but a stack update will do the diff and throw an error on any immutable tags update attempt.
   #   The tags are propagated to all resources created by the stack, including the stack itself.
   #   If a resource has its own tag with the same name as CF's it's not overwritten.
@@ -236,6 +240,24 @@ template do
           ],
       },
       :Path => '/',
+  }
+
+  # Use sub to set bucket names for an S3 Policy.
+  resource 'ManagedPolicy', :Type => "AWS::IAM::ManagedPolicy", :Properties => {
+    :Description => 'Access policy for S3 Buckets',
+    :PolicyDocument => {
+      :Version => "2012-10-17",
+      :Statement => [
+        {
+          :Action => ["s3:ListBucket"],
+          :Effect => "Allow",
+          :Resource => [
+            sub("arn:aws:s3:::${BucketName}"),
+            sub("arn:aws:s3:::${BaseName}${Hash}", {:BaseName => 'Bucket', :Hash => '3bsd73w'}),
+          ]
+        }
+      ]
+    }
   }
 
   # add conditions that can be used elsewhere in the template

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -252,6 +252,15 @@ def get_azs(region = '') { :'Fn::GetAZs' => region } end
 
 def import_value(value) { :'Fn::ImportValue' => value } end
 
+# There are two valid forms of Fn::Sub, with a map and without.
+def sub(sub_string, var_map = {})
+  if var_map.empty?
+    return { :'Fn::Sub' => sub_string }
+  else
+    return { :'Fn::Sub' => [sub_string, var_map] }
+  end
+end
+
 def join(delim, *list)
   case list.length
     when 0 then ''


### PR DESCRIPTION
## Description

Cloudformation has the [Fn:Sub](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html) function now, which provides functionality similar to Ruby's built-in string interpolation. We should add support for it.
## Steps to Test or Reproduce

There are two forms of `Fn::Sub`, both of which I've added to the DSL, using the same function to produce each, depending on parameters provided.

There's the verbose version where you declare your own variables:

``` ruby
sub("${var1}::AWS::${var2}", {:var1 => 'Yes', :var2 => 'Working'})
```

This produces this CFN output:

``` json
{
  "Fn::Sub": [
    "${var1}::AWS::${var2}",
    {
      "var1": "Yes",
      "var2": "Working"
    }
  ]
}
```

There's also a shorthand version that you can use when you're only referencing template params or logical ids that only requires passing in the string:

``` ruby
sub("arn:aws:s3:::${ParamName}/*")
```

That produces this output:

``` json
{
  "Fn::Sub": "arn:aws:s3:::${ParamName}/*"
}
```
### Environment

This should work for all modern templates.
## Deploy Notes

I'm guessing this will require a release, since it's an added function, but probably not a minor/major version.
## Todos
- [x] Pull Request
- [ ] Tests
- [ ] Documentation
## Request to Review

@jonaf/@temujin9 

Adding support for both forms of Fn::Sub.
