### PR TITLE
Adding a file read function that strips comments and empty lines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Reference a CloudFormation pseudo parameter.
 Additional capabilities for file inclusion, etc.
 - `tag(tag_name, tag_options_hash)`: add tags to the stack, which are inherited by all resources in that stack. `tag_options_hash` includes `:Value=>value` and `:Immutable=>true` properties. `tag(tag_value_hash)` is deprecated and will be removed in a future version.
 - `file(name)`: return the named file as a string, for further use
+- `file_min(name)`: returns the named file as a string, with Ruby or Bash comments removed, and newlines stripped out.
 - `load_from_file(filename)`: load the named file by a given type; currently handles YAML, JSON, and Ruby
 - `interpolate(string)`: embed CFN references into a string (`{{ref('Service')}}`) for later interpretation by the CFN engine
 - `Table.load(filename)`: load a table from the listed file, which can then be turned into mappings (via `get_map`)

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -331,6 +331,9 @@ end
 # Read the specified file and return its value as a string literal
 def file(filename) File.read(File.absolute_path(filename, File.dirname($PROGRAM_NAME))) end
 
+# Read in file, stripping comments and empty lines.
+def file_min(filename) File.readlines(File.absolute_path(filename, File.dirname($PROGRAM_NAME))).reject { |line| line =~ /#(?!\!).*/ }.reject { |c| c.strip.empty? }.join('') end
+
 # Interpolates a string like "NAME={{ref('Service')}}" and returns a CloudFormation "Fn::Join"
 # operation to collect the results.  Anything between {{ and }} is interpreted as a Ruby expression
 # and eval'd.  This is especially useful with Ruby "here" documents.


### PR DESCRIPTION
## Description
Adds a function to read in a file while stripping out Bash and Ruby style comments, as well as empty lines. This helps keep templates more readable, while allowing you to comment files as needed in source.

I didn't add it to the usage examples, since it's functionally used the same as `file(name)`, but I can if people feel that would be helpful.

## Steps to Test or Reproduce
You should be able to reproduce this by using it to read in a file like so:
```bash
#This is a comment

curl google.com
```
and it should be delivered as:

```bash
curl google.com
```

## Deploy Notes
This could require at least a patch version bump, since it's new functionality.

## Related Issues and PRs

## Todos
- [x] Pull Request
- [ ] Tests
- [ ] Documentation

## Request to Review
@jonaf/@temujin9 

