### PR TITLE
Make all methods public (remove 'private')

### DIFF
--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -187,7 +187,6 @@ class TemplateDSL < JsonObjectDSL
     end
   end
 
-  private
   def _get_parameter_from_cli(name, options)
     # basic request
     param_request = "Parameter '#{name}' (#{options[:Type]})"


### PR DESCRIPTION
Hi,

We're using this in a fairly complex larger system which needs to make use of some of these methods (particularly import_value()) outside of the regular DSLTemplate scope. This is necessary so that objects including intrinsic functions can be prepared in a modular style and compiled together to create a main template, as passing a JSON block to a DSLTemplate method seems to always result in it being converted into a string, so it's impossible to simply pass the JSON equivalent of the dsl helper function (such as import_value()) without using these (currently private) methods. Hope this is okay.