### PR TITLE
[Bug Fix] #116 Adds new Parameter class for --interactive mode parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ test/tmp
 test/version_tmp
 tmp
 .rvmrc
+/vendor/bundle

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -87,12 +87,14 @@ class TemplateDSL < JsonObjectDSL
     default(:Parameters, {})[name] = options
 
     if @interactive
-      @parameters[name] ||= _get_parameter_from_cli(name, options)
+      @parameters[name] ||= Parameter.new(_get_parameter_from_cli(name, options))
     else
       @parameters[name] ||= Parameter.new('')
-      @parameters[name].default = options[:Default]
-      @parameters[name].use_previous_value = options[:UsePreviousValue]
     end
+
+    # set various param options
+    @parameters[name].default = options[:Default]
+    @parameters[name].use_previous_value = options[:UsePreviousValue]
   end
 
   # Find parameters where the specified attribute is true then remove the attribute from the cfn template.


### PR DESCRIPTION
## Description
* Fixes interactive parameters and wraps them in the new Parameter object
* Adds `/vendor/bundle` to `.gitignore` such that `bundle install --path "vendor/bundle"` can be used for a development environment

## Related Issues and PRs

### Issues
 - [#116](https://github.com/bazaarvoice/cloudformation-ruby-dsl/issues/116)

## Request to Review
@jonaf/@temujin9 
