### PR TITLE
Sort existing and new template Hashes to compare them using diffy

### DIFF
--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'diffy'
   gem.add_runtime_dependency    'highline'
   gem.add_runtime_dependency    'rake'
+  gem.add_runtime_dependency    'deepsort'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'


### PR DESCRIPTION
## Description
As [diiffy](https://github.com/samg/diffy) compares existing and new CFN templates string by string we need to prepare output in the same (alphanumerical) order.

### Issues
- [#115](https://github.com/bazaarvoice/cloudformation-ruby-dsl/issues/115)

## Request to Review
@jonaf/@temujin9 