### PR TITLE
Use AWS::Region to look up the stack's region.

### DIFF
--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -151,7 +151,7 @@ def validate_action(action)
 end
 
 def cfn(template)
-  aws_cfn = AwsCfn.new({:region => template.aws_region, :aws_profile => template.aws_profile})
+  aws_cfn = AwsCfn.new({:region => template.default_region, :aws_profile => template.aws_profile})
   cfn_client = aws_cfn.cfn_client
 
   action = validate_action( ARGV[0] )

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -64,16 +64,16 @@ end
 class TemplateDSL < JsonObjectDSL
   attr_reader :parameters,
               :parameter_cli,
-              :aws_region,
               :nopretty,
               :stack_name,
+              :default_region,
               :aws_profile
 
   def initialize(options)
     @parameters  = options.fetch(:parameters, {})
     @interactive = options.fetch(:interactive, false)
     @stack_name  = options[:stack_name]
-    @aws_region  = options.fetch(:region, default_region)
+    @default_region  = options.fetch(:region, default_region)
     @aws_profile = options[:profile]
     @nopretty    = options.fetch(:nopretty, false)
     super()
@@ -325,6 +325,8 @@ def aws_no_value() ref("AWS::NoValue") end
 def aws_stack_id() ref("AWS::StackId") end
 
 def aws_stack_name() ref("AWS::StackName") end
+
+def aws_region() ref("AWS::Region") end
 
 # deprecated, for backward compatibility
 def no_value()


### PR DESCRIPTION
## Description
The `aws_region()` function behaves differently than most of the other `aws_` functions, in that it isn't a passthrough to a `ref(AWS::KEY)` CloudFormation variable, and instead uses the default region of the computer compiling the template.

This can cause unexpected behavior in circumstances when you want to deploy a template to a region other than the device's default. Using the `AWS::Region` value is more reliable, as it allows the region to be determined when the stack is deployed, instead of having to re-expand the template for each region.

## Steps to Test or Reproduce
Expanding a template now will cause `aws_region` to substitute in with the value of the computer's default AWS Region. With this change, you should see it compile to a Ref to `AWS::Region`.

## Deploy Notes
This is hypothetically a breaking change, but I'm not sure why someone would be relying on the current behavior to resolve `aws_region` to a different value than the value at deploy time in `AWS::Region`, so it should be fairly safe.

## Related Issues and PRs

## Todos
- [x] Pull Request
- [x] Tests
- [x] Documentation

## Request to Review
@jonaf/@temujin9 
