### PR TITLE
Add option --s3-bucket to upload templates to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Make the resulting file executable (`chmod +x [NEW_NAME.rb]`). It can respond to
     2 - there are differences between an existing stack and your template
 ```
 - `validate`: run validation against the stack definition
-- `create`: create a new stack from the output
-- `update`: update an existing stack from the output. Produces following exit codes:
+- `create`: create a new stack from the output (takes optional `--s3-bucket` to upload the template to the specified S3 bucket prior to creating the stack)
+- `update`: update an existing stack from the output (takes optional `--s3-bucket` to upload the template to the specified S3 bucket prior to creating the stack). Produces following exit codes:
 ```
     0 - update finished successfully
     1 - no updates to perform, stack doesn't exist, unable to update immutable parameter or tag, AWS ServiceError exception
@@ -62,7 +62,7 @@ Command line options similar to cloudformation commands, but parsed by the dsl.
 - `--stack-name`
 - `--region`
 - `--parameters`
-- `--tag  `
+- `--tag`
 
 Any other parameters are passed directly onto cloudformation. (--disable-rollback for instance)
 

--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -620,7 +620,7 @@ template.rb create --stack-name my_stack --parameters "BucketName=bucket-s3-stat
       else
         template_path = "#{Time.now.strftime("%s")}/#{stack_name}.json"
         # assumption: JSON is the only supported serialization format (YAML not allowed)
-        template_url = "s3://#{template.s3_bucket}/#{template_path}"
+        template_url = "https://s3.amazonaws.com/#{template.s3_bucket}/#{template_path}"
         s3_client.put_object({
           bucket: template.s3_bucket,
           key: template_path,

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -4,7 +4,7 @@ require 'json'
 
 # Formats a template as JSON
 def generate_template(template)
-  format_json template, !template.nopretty
+  generate_json template, !template.nopretty
 end
 
 def generate_json(data, pretty = true)

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -67,7 +67,8 @@ class TemplateDSL < JsonObjectDSL
               :aws_region,
               :nopretty,
               :stack_name,
-              :aws_profile
+              :aws_profile,
+              :s3_bucket
 
   def initialize(options)
     @parameters  = options.fetch(:parameters, {})
@@ -76,6 +77,7 @@ class TemplateDSL < JsonObjectDSL
     @aws_region  = options.fetch(:region, default_region)
     @aws_profile = options[:profile]
     @nopretty    = options.fetch(:nopretty, false)
+    @s3_bucket   = options.fetch(:s3_bucket, nil)
     super()
   end
 


### PR DESCRIPTION
## Description
Sometimes, you just need more than 52K for a template. You can get 400K if you upload the template to S3 first. See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html

## Steps to Test or Reproduce
1. Checkout this PR.
2. Create a bucket of your own (which you must have access to)
3. Create a Cloudformation stack as normal, but supply the bucket name to the DSL using the `--s3-bucket` argument.

Example:

```
./my-cfn-stack.rb create MY_STACK --s3-bucket MY_BUCKET_NAME
```

### Environment
```
$ uname -a
Darwin jfenocchi-r.local 16.6.0 Darwin Kernel Version 16.6.0: Fri Apr 14 16:13:31 PDT 2017; root:xnu-3789.60.24~4/RELEASE_X86_64 x86_64
$ ruby --version
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]
```

## Deploy Notes
This change should constitute a minor version increase, as it is a net new feature.
