### PR TITLE
Handle attributes split on dot in name

### DIFF
--- a/bin/cfntemplate-to-ruby
+++ b/bin/cfntemplate-to-ruby
@@ -312,7 +312,7 @@ def simplify(val)
         when k == 'Fn::FindInMap'
           FnCall.new 'find_in_map', v
         when k == 'Fn::GetAtt'
-          FnCall.new 'get_att', v
+          FnCall.new 'get_att', [v.first, v.drop(1).join('.')]
         when k == 'Fn::GetAZs'
           FnCall.new 'get_azs', v != '' ? [v] : []
         when k == 'Fn::Join'


### PR DESCRIPTION
## Description
Attributes that have a dot in the name causing `Fn::GetAtt` to have more than two elements generates bad Ruby code.

## Steps to Test or Reproduce
1. Create a CloudFormation template that uses `Fn::GetAtt`. Using an example from the documentation reproduces this.
```
{
    "AWSTemplateFormatVersion": "2010-09-09",
    "Resources": {
        "myELB": {
            "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
            "Properties": {
                "AvailabilityZones": [
                    "eu-west-1a"
                ],
                "Listeners": [
                    {
                        "LoadBalancerPort": "80",
                        "InstancePort": "80",
                        "Protocol": "HTTP"
                    }
                ]
            }
        },
        "myELBIngressGroup": {
            "Type": "AWS::EC2::SecurityGroup",
            "Properties": {
                "GroupDescription": "ELB ingress group",
                "SecurityGroupIngress": [
                    {
                        "IpProtocol": "tcp",
                        "FromPort": "80",
                        "ToPort": "80",
                        "SourceSecurityGroupOwnerId": {
                            "Fn::GetAtt": [
                                "myELB",
                                "SourceSecurityGroup",
                                "OwnerAlias"
                            ]
                        },
                        "SourceSecurityGroupName": {
                            "Fn::GetAtt": [
                                "myELB",
                                "SourceSecurityGroup",
                                "GroupName"
                            ]
                        }
                    }
                ]
            }
        }
    }
}
```
2. Run `cfntemplate-to-ruby` on the template.
3. Notice that there are three arguments given to `get_att()`
```
get_att('myELB', 'SourceSecurityGroup', 'OwnerAlias')
```
4. Run ruby on the generated Ruby code. An error occurs:
```
.../cloudformation-ruby-dsl-1.4.6/lib/cloudformation-ruby-dsl/dsl.rb:264:in `get_att': wrong number of arguments (given 3, expected 2) (ArgumentError)
```

### Environment
Running on Ubuntu
`ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]`
Environment shouldn't matter for this issue.

## Deploy Notes
Minor fix for something that could be worked around.

## Related Issues and PRs

### Issues
 - Fixes #124

## Todos
- [x] Pull Request
- [ ] Tests
- [ ] Documentation

## Request to Review
@jonaf/@temujin9 
