### PR TITLE
Fix MissingCredentialsError error when using AWS API call in template

### DIFF
--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -38,7 +38,7 @@ class AwsCfn
     Aws.config[:region] = args[:region] if args.key?(:region)
     # Profile definition was replaced with environment variables
     if args.key?(:aws_profile) && !(args[:aws_profile].nil? || args[:aws_profile].empty?)
-        ENV['AWS_PROFILE'] = args[:aws_profile]
+        Aws.config[:profile] = args[:aws_profile]
         ENV['AWS_ACCESS_KEY'] = nil
         ENV['AWS_ACCESS_KEY_ID'] = nil
         ENV['AMAZON_ACCESS_KEY_ID'] = nil


### PR DESCRIPTION
## Description
Template which contain AWS API call will raise Aws::Errors::MissingCredentialsError error.

## Steps to Test or Reproduce
1. Create a CloudFormation template with next content:
``` ruby
#!/usr/bin/env ruby

require 'bundler/setup'
require 'cloudformation-ruby-dsl/cfntemplate'
require 'cloudformation-ruby-dsl/table'

template do

  resource 'SNS', :Type => 'AWS::SNS::Topic', :Properties => {
      :DisplayName => Aws::CloudFormation::Client.new(profile: aws_profile, region: aws_region).list_stacks.stack_summaries.first.stack_id
  }

end.exec!

```
2. Run expand command with profile and region parameters:
``` bash
$ ruby test.rb expand --region eu-west-1 --profile qa
{
  "Resources": {
    "SNS": {
      "Type": "AWS::SNS::Topic",
      "Properties": {
        "DisplayName": "arn:aws:cloudformation:eu-west-1:54**********:stack/qa-********/40829**********"
      }
    }
  }
}
```
3. Run create stack operation:
``` bash
$ ruby test.rb create --stack-name test --region eu-west-1 --profile qa
/var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/plugins/request_signer.rb:100:in `require_credentials': unable to sign request without credentials set (Aws::Errors::MissingCredentialsError)
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/plugins/request_signer.rb:90:in `sign_authenticated_requests'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/plugins/request_signer.rb:83:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/plugins/helpful_socket_errors.rb:10:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/plugins/retry_errors.rb:87:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/query/handler.rb:27:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/plugins/user_agent.rb:12:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/seahorse/client/plugins/endpoint.rb:41:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/seahorse/client/plugins/response_target.rb:21:in `call'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/seahorse/client/request.rb:70:in `send_request'
	from /var/lib/gems/2.3.0/gems/aws-sdk-core-2.5.1/lib/seahorse/client/base.rb:207:in `block (2 levels) in define_operation_methods'
	from /var/lib/gems/2.3.0/gems/cloudformation-ruby-dsl-1.4.6/lib/cloudformation-ruby-dsl/cfntemplate.rb:368:in `cfn'
	from /var/lib/gems/2.3.0/gems/cloudformation-ruby-dsl-1.4.6/lib/cloudformation-ruby-dsl/cfntemplate.rb:658:in `exec!'
	from test.rb:17:in `<main>'

```
### Environment
Tested with: 
* ruby 2.3.1p112 (2016-04-26) [x86_64-linux-gnu]
* cloudformation-ruby-dsl-1.4.6
* aws-sdk-2.5.1 and aws-sdk-2.10.86

## Todos
- [x] Pull Request
- [ ] Tests
- [ ] Documentation

## Request to Review
@jonaf/@temujin9 
