### PR TITLE
Added a possibility to enable termination protection for stack creation only

### DIFF
--- a/cloudformation-ruby-dsl.gemspec
+++ b/cloudformation-ruby-dsl.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency    'detabulator'
   gem.add_runtime_dependency    'json'
   gem.add_runtime_dependency    'bundler'
-  gem.add_runtime_dependency    'aws-sdk', '>=2.5.1'
+  gem.add_runtime_dependency    'aws-sdk', '>=3.0.1'
   gem.add_runtime_dependency    'diffy'
   gem.add_runtime_dependency    'highline'
   gem.add_runtime_dependency    'rake'

--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -86,13 +86,14 @@ end
 # Parse command-line arguments and return the parameters and region
 def parse_args
   args = {
-    :stack_name  => nil,
-    :parameters  => {},
-    :interactive => false,
-    :region      => default_region,
-    :profile     => nil,
-    :nopretty    => false,
-    :s3_bucket   => nil,
+    :stack_name        => nil,
+    :parameters        => {},
+    :interactive       => false,
+    :region            => default_region,
+    :profile           => nil,
+    :nopretty          => false,
+    :s3_bucket         => nil,
+    :enable_protection => false,
   }
   ARGV.slice_before(/^--/).each do |name, value|
     case name
@@ -110,6 +111,8 @@ def parse_args
       args[:nopretty] = true
     when '--s3-bucket'
       args[:s3_bucket] = value
+    when '--enable-termination-protection'
+      args[:enable_protection] = true
     end
   end
 
@@ -184,7 +187,7 @@ def cfn(template)
   template_string = generate_template(template)
 
   # Derive stack name from ARGV
-  _, options = extract_options(ARGV[1..-1], %w(--nopretty), %w(--profile --stack-name --region --parameters --tag --s3-bucket))
+  _, options = extract_options(ARGV[1..-1], %w(--nopretty), %w(--profile --stack-name --region --parameters --tag --s3-bucket --enable-termination-protection))
   # If the first argument is not an option and stack_name is undefined, assume it's the stack name
   # The second argument, if present, is the resource name used by the describe-resource command
   if template.stack_name.nil?
@@ -377,6 +380,7 @@ template.rb create --stack-name my_stack --parameters "BucketName=bucket-s3-stat
           parameters: template.parameters.map { |k,v| {parameter_key: k, parameter_value: v}}.to_a,
           tags: cfn_tags.map { |k,v| {"key" => k.to_s, "value" => v} }.to_a,
           capabilities: ["CAPABILITY_NAMED_IAM"],
+          enable_termination_protection: template.enable_protection,
       }
 
       # If the user supplied the --s3-bucket option and

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -68,16 +68,18 @@ class TemplateDSL < JsonObjectDSL
               :nopretty,
               :stack_name,
               :aws_profile,
-              :s3_bucket
+              :s3_bucket,
+              :enable_protection
 
   def initialize(options)
-    @parameters  = options.fetch(:parameters, {})
-    @interactive = options.fetch(:interactive, false)
-    @stack_name  = options[:stack_name]
-    @aws_region  = options.fetch(:region, default_region)
-    @aws_profile = options[:profile]
-    @nopretty    = options.fetch(:nopretty, false)
-    @s3_bucket   = options.fetch(:s3_bucket, nil)
+    @parameters        = options.fetch(:parameters, {})
+    @interactive       = options.fetch(:interactive, false)
+    @stack_name        = options[:stack_name]
+    @aws_region        = options.fetch(:region, default_region)
+    @aws_profile       = options[:profile]
+    @nopretty          = options.fetch(:nopretty, false)
+    @s3_bucket         = options.fetch(:s3_bucket, nil)
+    @enable_protection = options.fetch(:enable_protection, false)
     super()
   end
 


### PR DESCRIPTION
Since Amazon added the [termination protection](https://aws.amazon.com/about-aws/whats-new/2017/09/aws-cloudformation-provides-stack-termination-protection/) of CF stacks  it makes sense to implement it here.

I've added this functionality to stack creation only. I believe, if we're going to protect our stack, this protection should be disabled manually only, so I see no any sense to change it in "update" method.

Protection can be enabled with option
```
--enable-termination-protection
```