### PR TITLE
Add Fn::Cidr function

### DIFF
--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -261,6 +261,8 @@ end
 
 def base64(value) { :'Fn::Base64' => value } end
 
+def cidr(ipblock, count, cidrbits) { :'Fn::Cidr' => [ ipblock, count, cidrbits ] } end
+
 def find_in_map(map, key, name) { :'Fn::FindInMap' => [ map, key, name ] } end
 
 def get_att(resource, attribute) { :'Fn::GetAtt' => [ resource, attribute ] } end


### PR DESCRIPTION
## Description
Adding cidr function for Fn::Cidr.

## Steps to Test or Reproduce
Example
```
select(0, cird(get_att('vpc', 'CidrBlock), 256, 24)) 
```
### Environment
This PR

## Deploy Notes
None

## Related Issues and PRs

### Issues
 - #134 

### PRs

## Todos
- [x] Pull Request
- [ ] Tests
- [ ] Documentation

## Request to Review
@jonaf/@temujin9 
